### PR TITLE
increase version number to 0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
  
 setup(
     name='mytreepy',
-    version='0.1',
+    version='0.2',
     url='https://github.com/NoelBird/pytree',
     license='MIT',
     author='NoelBird',


### PR DESCRIPTION
This patch upgraded the version id from 0.1 to 0.2.
In 0.2 version, root dir name is added in the print result.

The 0.2 version have already been deployed through PyPI.